### PR TITLE
Feature/record change bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Issues are tracked in AppGyver's [unified issue tracker](https://github.com/appgyver/steroids/issues) – please post bug reports and feature requests there.
 
+## 1.0.11 (TODO)
+
+Features:
+- Added 3-way data binding support for single records by `one(123).whenChanged` on `supersonic.data.model`
+
+Bugfixes:
+- Resolved issue with `defaultStorage` for `supersonic.data.model` not being defined and the `cache` flag not working without specifying a storage
+
 ## 1.0.10 (2014-12-22)
 
 Bugfixes:

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     }
   },
   "dependencies": {
-    "ag-data": "^0.7.1",
+    "ag-data": "^0.8.0",
     "baconjs": "^0.7.34",
     "bluebird": "2.3.11",
     "coffee-script": "1.8.0",

--- a/src/supersonic/core/data/index.coffee
+++ b/src/supersonic/core/data/index.coffee
@@ -1,6 +1,6 @@
 # KLUDGE: localforage explodes if actually included in node
 localforage = switch
-  when global? then {}
+  when !window? then {}
   else require 'localforage'
 
 module.exports = (logger, window) ->

--- a/src/supersonic/core/data/model.coffee
+++ b/src/supersonic/core/data/model.coffee
@@ -126,7 +126,7 @@ module.exports = (logger, window, defaultStorage) ->
 #   supersonic.logger.log("First element of updated Task collection: ", updatedTasks[0]);
 # });
 #
-# // Later on, we can unsusbcribe the listener
+# // Later on, we can stop listening to updates
 # unsubscribe();
 ###
 

--- a/src/supersonic/core/data/model.coffee
+++ b/src/supersonic/core/data/model.coffee
@@ -97,6 +97,7 @@ module.exports = (logger, window, defaultStorage) ->
 # @define {Function} find Returns a [`Promise`](/supersonic/guides/technical-concepts/promises/) that resolves to a Model instance representing the record with the given id.
 # @define {Function} fromJson Create a persisted Model instance from serialized data.
 ###
+
 ###
 # @namespace supersonic.data
 # @name Model.all

--- a/src/supersonic/core/data/model.coffee
+++ b/src/supersonic/core/data/model.coffee
@@ -117,7 +117,7 @@ module.exports = (logger, window, defaultStorage) ->
 # @define {Integer} options.interval=1000 An integer defining how often the backend is polled for new data, in ms.
 # @returnsDescription
 # An object with the `whenChanged` property, which accepts a recurring callback function that gets triggered when new data is available.
-# @define {=>Function} whenChanged Called with a Collection matching the original query. Called every `options.interval` ms, but only when new data is available. Returns a function that can be used to unsubsribe from the update stream.
+# @define {=>Function} whenChanged Called with a Collection matching the original query. Called every `options.interval` ms, but only when new data is available. Returns a function that can be used to unsubscribe from the update stream.
 # @define {=>Function} whenChanged.unsubscribe Call this function to stop listening for data changes.
 # @exampleCoffeeScript
 # unsubscribe = supersonic.data.model('task').all(queryParameters, options).whenChanged (updatedTasks)->

--- a/src/supersonic/core/data/model.coffee
+++ b/src/supersonic/core/data/model.coffee
@@ -132,6 +132,37 @@ module.exports = (logger, window, defaultStorage) ->
 ###
 
 ###
+# @namespace supersonic.data
+# @name Model.one
+# @function
+# @type
+# one: (
+#   id: String
+# ) =>
+#   whenChanged: (Collection) =>
+#     unsubscribe: Function
+# @description
+# Find a single record from the cloud by an id. The results are made available as a stream that gets updated with the latest data every `interval` ms.
+# @define {String} id An id string matching a record in the cloud resource represented by this Model class.
+# @define {Object} options An optional options object.
+# @define {Integer} options.interval=1000 An integer defining how often the backend is polled for new data, in ms.
+# @returnsDescription
+# An object with the `whenChanged` property, which accepts a recurring callback function that gets triggered when new data is available.
+# @define {=>Function} whenChanged Called with a Model matching the `id`. Called every `options.interval` ms, but only when new data is available. Returns a function that can be used to unsubscribe from the update stream.
+# @define {=>Function} whenChanged.unsubscribe Call this function to stop listening for data changes.
+# @exampleCoffeeScript
+# unsubscribe = supersonic.data.model('task').one('123', options).whenChanged (updatedTask)->
+#   supersonic.logger.log "Most recent data on task 123: ", updatedTask
+# @exampleJavaScript
+# var unsubscribe = supersonic.data.model('task').one('123', options).whenChanged( function(updatedTask) {
+#   supersonic.logger.log("Most recent data on task 123: ", updatedTask);
+# });
+#
+# // Later on, we can stop listening to updates
+# unsubscribe();
+###
+
+###
  # @namespace supersonic.data
  # @name Model.findAll
  # @function

--- a/testApp/app/data/scripts/IndexController.coffee
+++ b/testApp/app/data/scripts/IndexController.coffee
@@ -4,10 +4,15 @@ angular
     $scope.tasks = null
     $scope.showSpinner = true
 
-    Task.all({}, {interval: 1000}).whenChanged (tasks)->
-      $scope.$apply ->
-        $scope.tasks = tasks
-        $scope.showSpinner = false
+    stopUpdating = null
+    supersonic.ui.views.current.whenVisible ->
+      stopUpdating = Task.all({}, {interval: 1000}).whenChanged (tasks) ->
+        $scope.$apply ->
+          $scope.tasks = tasks
+          $scope.showSpinner = false
+    supersonic.ui.views.current.whenHidden ->
+      stopUpdating?()
+      stopUpdating = null
 
     supersonic.data.channel("events").subscribe (message)->
       supersonic.ui.dialog.alert "Received message! #{message}"

--- a/testApp/app/data/scripts/ShowController.coffee
+++ b/testApp/app/data/scripts/ShowController.coffee
@@ -4,11 +4,16 @@ angular
     $scope.task = null
     $scope.showSpinner = true
 
+    stopUpdating = null
     supersonic.ui.views.current.whenVisible ->
-      Task.find(steroids.view.params.id).then (task)->
+      stopUpdating = Task.one(steroids.view.params.id, {interval: 1000}).whenChanged (task) ->
         $scope.$apply ->
           $scope.task = task
           $scope.showSpinner = false
+
+    supersonic.ui.views.current.whenHidden ->
+      stopUpdating?()
+      stopUpdating = null
 
     $scope.remove = (id) ->
       $scope.showSpinner = true


### PR DESCRIPTION
Adds support for `model.one(id).whenChanged`.

Fixes issue with `defaultStorage` for `supersonic.data.model` not being defined.