### PR TITLE
Typo

### DIFF
--- a/src/supersonic/core/ui/layers.coffee
+++ b/src/supersonic/core/ui/layers.coffee
@@ -27,7 +27,7 @@ module.exports = (steroids, log) ->
    # ) => Promise
    # @define {View|String} view A View or View identifier to be pushed on top of the navigation stack.
    # @define {Object} options An optional options object.
-   # @define {String|Object} options.params An object or JSON string of optional parameters to be passed to the target View, accessible via `supersonic.ui.views.params.current`.
+   # @define {String|Object} options.params An object or JSON string of optional parameters to be passed to the target View, accessible via `supersonic.ui.views.current.params.onValue(callback)`.
    # @define {Animation} options.animation=slideFromRight **(iOS-only)** A custom transition animation, definable by calling `supersonic.ui.animate()`.
    # @returnsDescription
    # A [`Promise`](/supersonic/guides/technical-concepts/promises/) that gets resolved with the provided View instance once the push has started. If the view cannot be pushed, the promise is rejected.

--- a/src/supersonic/core/ui/layers.coffee
+++ b/src/supersonic/core/ui/layers.coffee
@@ -27,7 +27,7 @@ module.exports = (steroids, log) ->
    # ) => Promise
    # @define {View|String} view A View or View identifier to be pushed on top of the navigation stack.
    # @define {Object} options An optional options object.
-   # @define {String|Object} options.params On object or JSON string of optional parameters to be passed to the target View, accessible via `supersonic.ui.views.params.current`.
+   # @define {String|Object} options.params An object or JSON string of optional parameters to be passed to the target View, accessible via `supersonic.ui.views.params.current`.
    # @define {Animation} options.animation=slideFromRight **(iOS-only)** A custom transition animation, definable by calling `supersonic.ui.animate()`.
    # @returnsDescription
    # A [`Promise`](/supersonic/guides/technical-concepts/promises/) that gets resolved with the provided View instance once the push has started. If the view cannot be pushed, the promise is rejected.


### PR DESCRIPTION
Also, should `supersonic.ui.views.params.current` be `supersonic.ui.views.current.params`?