### PR TITLE
Feature/module attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "bluebird": "2.9.14",
     "coffee-script": "1.8.0",
     "deep-equal": "1.0.0",
-    "localforage": "1.2.0"
+    "localforage": "1.2.0",
+    "qs": "3.1.0"
   }
 }

--- a/src/supersonic/core/module/attributes.coffee
+++ b/src/supersonic/core/module/attributes.coffee
@@ -1,0 +1,37 @@
+querystring = require 'qs'
+
+module.exports = (logger) ->
+
+  getModuleFrameAttribute = (name) ->
+    window?.frameElement?.getAttribute? "data-#{name}"
+
+  getUrlParamAttribute = do ->
+    getHrefParamsString = ->
+      href = window?.parent?.location.href || ""
+      href.slice(href.indexOf('?') + 1)
+
+    getParentLocationHrefParams = ->
+      querystring.parse getHrefParamsString()
+
+    params = null
+    (name) ->
+      params = getParentLocationHrefParams() unless params?
+      params[name]
+
+
+  getAttribute = (name, defaultValue = null) ->
+    for get in [getModuleFrameAttribute, getUrlParamAttribute]
+      value = get name
+
+      if value?
+        return value
+
+    defaultValue
+
+  hasAttribute = (name) ->
+    getModuleFrameAttribute(name)? || getUrlParamAttribute(name)?
+
+  return {
+    get: getAttribute
+    has: hasAttribute
+  }

--- a/src/supersonic/core/module/index.coffee
+++ b/src/supersonic/core/module/index.coffee
@@ -1,37 +1,3 @@
 
-Promise = require 'bluebird'
-
-module.exports = enterpriseModule = (logger) ->
-
-  initialModuleElements = Promise.delay(0).then ->
-    moduleElements = document.querySelectorAll("iframe[data-module]")
-
-    for element in moduleElements
-      do (element) ->
-        observeModuleElementSize(element)
-
-        element.onload = ->
-          resizeModuleElement(element)
-
-    moduleElements
-
-  observeModuleElementSize = (moduleElement) ->
-    moduleElement.contentDocument.onreadystatechange = ->
-      if (moduleElement.contentDocument.readyState == "complete")
-        createObserverFor(moduleElement)
-
-
-  createObserverFor = (moduleElement) ->
-    moduleContentObserver = new MutationObserver ->
-      resizeModuleElement(moduleElement)
-
-    moduleContentObserver.observe(moduleElement.contentDocument.body, {childList: true, subtree: true})
-
-  resizeModuleElement = (moduleElement) ->
-    unit = "px"
-    height = moduleElement.contentDocument.body.scrollHeight
-
-    moduleElement.style.height = height+unit
-
-
-  return { initialModuleElements }
+module.exports = module = (logger) ->
+  initialModuleElements: require('./initial-module-elements')(logger)

--- a/src/supersonic/core/module/index.coffee
+++ b/src/supersonic/core/module/index.coffee
@@ -1,3 +1,4 @@
 
-module.exports = module = (logger) ->
+module.exports = (logger) ->
   initialModuleElements: require('./initial-module-elements')(logger)
+  attributes: require('./attributes')(logger)

--- a/src/supersonic/core/module/initial-module-elements.coffee
+++ b/src/supersonic/core/module/initial-module-elements.coffee
@@ -1,0 +1,35 @@
+Promise = require 'bluebird'
+
+module.exports = (logger) ->
+  initialModuleElements = Promise.delay(0).then ->
+    moduleElements = document.querySelectorAll("iframe[data-module]")
+
+    for element in moduleElements
+      do (element) ->
+        observeModuleElementSize(element)
+
+        element.onload = ->
+          resizeModuleElement(element)
+
+    moduleElements
+
+  observeModuleElementSize = (moduleElement) ->
+    moduleElement.contentDocument.onreadystatechange = ->
+      if (moduleElement.contentDocument.readyState == "complete")
+        createObserverFor(moduleElement)
+
+
+  createObserverFor = (moduleElement) ->
+    moduleContentObserver = new MutationObserver ->
+      resizeModuleElement(moduleElement)
+
+    moduleContentObserver.observe(moduleElement.contentDocument.body, {childList: true, subtree: true})
+
+  resizeModuleElement = (moduleElement) ->
+    unit = "px"
+    height = moduleElement.contentDocument.body.scrollHeight
+
+    moduleElement.style.height = height+unit
+
+  return initialModuleElements
+

--- a/src/supersonic/core/ui/View.coffee
+++ b/src/supersonic/core/ui/View.coffee
@@ -149,7 +149,7 @@ module.exports = (steroids, log) ->
             onSuccess: =>
               @id = webView.id # mark started
               resolve @
-            onFailure: (error)=>
+            onFailure: (error) ->
               reject new Error error.errorDescription
 
 

--- a/testApp/app/common/views/index.html
+++ b/testApp/app/common/views/index.html
@@ -72,6 +72,12 @@
     </li>
   </super-navigate>
 
+  <super-navigate location="module#index">
+    <li class="item item-icon-right">
+      Module APIs <i class="icon super-ios7-arrow-right"></i>
+    </li>
+  </super-navigate>
+
   <super-navigate location="initial#show">
     <li class="item item-icon-right">
       Initial view APIs <i class="icon super-ios7-arrow-right"></i>

--- a/testApp/app/module/scripts/AttributeIframeController.coffee
+++ b/testApp/app/module/scripts/AttributeIframeController.coffee
@@ -1,0 +1,13 @@
+angular
+  .module('module')
+  .controller 'AttributeIframeController', ($scope) ->
+    attributes = supersonic.module.attributes
+
+    $scope.hasIframeAttribute = attributes.has('attribute-from-iframe')
+    $scope.iframeAttributeValue = attributes.get('attribute-from-iframe')
+
+    $scope.hasUrlParamAttribute = attributes.has('attribute-from-url-param')
+    $scope.urlParamAttributeValue = attributes.get('attribute-from-url-param')
+
+    $scope.hasAttributeFromNowhere = attributes.has('attribute-from-nowhere')
+    $scope.attributeFromNowhereValue = attributes.get('attribute-from-nowhere', 'provided default value')

--- a/testApp/app/module/scripts/IframeSizeAutoadjustController.coffee
+++ b/testApp/app/module/scripts/IframeSizeAutoadjustController.coffee
@@ -1,6 +1,6 @@
 angular
   .module('module')
-  .controller 'IndexController', ($scope) ->
+  .controller 'IframeSizeAutoadjustController', ($scope) ->
     supersonic.module.initialModuleElements.then(
       (elements) ->
         $scope.moduleElements = elements

--- a/testApp/app/module/views/attribute-iframe.html
+++ b/testApp/app/module/views/attribute-iframe.html
@@ -1,0 +1,17 @@
+
+<div ng-controller="AttributeIframeController">
+  <h4>supersonic.module.attributes</h4>
+  <dl>
+    <dt><code>attribute-from-iframe</code>:</dt>
+    <dd>Present: {{ hasIframeAttribute }}</dd>
+    <dd>Value: {{ iframeAttributeValue }}</dd>
+
+    <dt><code>attribute-from-url-param</code>:</dt>
+    <dd ng->Present: {{ hasUrlParamAttribute }}</dd>
+    <dd>Value: {{ urlParamAttributeValue }}</dd>
+
+    <dt><code>attribute-from-nowhere</code>:</dt>
+    <dd>Present: {{ hasAttributeFromNowhere }}</dd>
+    <dd>Value: {{ attributeFromNowhereValue }}</dd>
+  </dl>
+</div>

--- a/testApp/app/module/views/attributes.html
+++ b/testApp/app/module/views/attributes.html
@@ -1,0 +1,10 @@
+<div>
+
+  <super-navbar>
+    <super-navbar-title>
+      Attributes
+    </super-navbar-title>
+  </super-navbar>
+
+  <iframe data-module src="attribute-iframe.html" data-attribute-from-iframe="right here"></iframe>
+</div>

--- a/testApp/app/module/views/growing-module-iframe.html
+++ b/testApp/app/module/views/growing-module-iframe.html
@@ -6,10 +6,6 @@
   I am the module with initial content.
 </p>
 
-<p>
-  Hello!
-</p>
-
 <div id="appendable-element">
 </div>
 

--- a/testApp/app/module/views/iframe-size-autoadjust.html
+++ b/testApp/app/module/views/iframe-size-autoadjust.html
@@ -1,0 +1,33 @@
+<style>
+
+  body {
+    margin: 0;
+    padding: 0;
+  }
+  iframe {
+    height: 30px;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    border: 1px black solid;
+  }
+</style>
+
+<div ng-controller="IframeSizeAutoadjustController">
+
+  <super-navbar>
+    <super-navbar-title>
+      Iframe size autoadjust
+    </super-navbar-title>
+  </super-navbar>
+
+  <div>
+    <p>Found the following iframes:</p>
+    <ul>
+      <li ng-repeat="moduleElement in moduleElements">{{ moduleElement.src }}</li>
+    </ul>
+  <div>
+
+  <iframe data-module src="growing-module-iframe.html"></iframe>
+
+</div>

--- a/testApp/app/module/views/index.html
+++ b/testApp/app/module/views/index.html
@@ -1,39 +1,16 @@
-<style>
-
-  body {
-    margin: 0;
-    padding: 0;
-  }
-  iframe {
-    height: 30px;
-    width: 100%;
-    margin: 0;
-    padding: 0;
-    border: 1px black solid;
-  }
-</style>
-
-<div ng-controller="IndexController">
+<div>
 
   <super-navbar>
     <super-navbar-title>
-      Module Index
+      Module APIs
     </super-navbar-title>
   </super-navbar>
 
-
-  <div class="padding">
-    <h1>Pow! Here's the Enterprise Module!</h1>
-  </div>
-
-  <div>
-    Found the following iframes:
-    <ul>
-      <li ng-repeat="moduleElement in moduleElements">{{ moduleElement.src }}</li>
-    </ul>
-  <div>
-
-
-  <iframe data-module src="module-index.html"></iframe>
-
+  <ul class="list">
+    <super-navigate location="module#iframe-size-autoadjust">
+      <li class="item item-icon-right">
+        Iframe size autoadjust <i class="icon super-ios7-arrow-right"></i>
+      </li>
+    </super-navigate>
+  </ul>
 </div>

--- a/testApp/app/module/views/index.html
+++ b/testApp/app/module/views/index.html
@@ -7,6 +7,11 @@
   </super-navbar>
 
   <ul class="list">
+    <super-navigate location="module#attributes?attribute-from-url-param=present">
+      <li class="item item-icon-right">
+        Attributes <i class="icon super-ios7-arrow-right"></i>
+      </li>
+    </super-navigate>
     <super-navigate location="module#iframe-size-autoadjust">
       <li class="item item-icon-right">
         Iframe size autoadjust <i class="icon super-ios7-arrow-right"></i>

--- a/testSpecApp/app/module/index.coffee
+++ b/testSpecApp/app/module/index.coffee
@@ -1,0 +1,2 @@
+expect = window.chai.expect
+window.chai.should()

--- a/testSpecApp/app/module/scripts/AttributesSpec.coffee
+++ b/testSpecApp/app/module/scripts/AttributesSpec.coffee
@@ -1,0 +1,29 @@
+describe "supersonic.module.attributes", ->
+  it "should be defined", ->
+    supersonic.module.attributes.should.be.defined
+
+  describe "get", ->
+    it "is a function", ->
+      supersonic.module.attributes.get.should.be.a 'function'
+
+    it "can retrieve an attribute from the wrapping iframe element", ->
+      supersonic.module.attributes.get('attribute-from-iframe').should.equal 'right here'
+
+    it "can retrieve an attribute from the containing window's location's query string", ->
+      supersonic.module.attributes.get('attribute-from-url-param').should.equal 'present'
+
+    it "can be provided with a default value in case the attribute does not exist", ->
+      supersonic.module.attributes.get('attribute-from-nowhere', 'default value').should.equal 'default value'
+
+  describe "has", ->
+    it "is a function", ->
+      supersonic.module.attributes.has.should.be.a 'function'
+
+    it "returns false if attribute is not available anywhere", ->
+      supersonic.module.attributes.has('attribute-from-nowhere').should.equal false
+
+    it "can report existence of an attribute on the wrapping iframe element", ->
+      supersonic.module.attributes.has('attribute-from-iframe').should.equal true
+
+    it "can report existence of a param on the containing window's location's query string", ->
+      supersonic.module.attributes.has('attribute-from-url-param').should.equal true

--- a/testSpecApp/app/module/views/ModuleSpec.html
+++ b/testSpecApp/app/module/views/ModuleSpec.html
@@ -1,0 +1,1 @@
+  <iframe data-module src="ModuleSpecFrame.html" data-attribute-from-iframe="right here"></iframe>

--- a/testSpecApp/app/module/views/ModuleSpecFrame.html
+++ b/testSpecApp/app/module/views/ModuleSpecFrame.html
@@ -1,0 +1,1 @@
+<script type="text/javascript" src="/app/module.js"></script>

--- a/testSpecApp/app/test-index/views/index.html
+++ b/testSpecApp/app/test-index/views/index.html
@@ -38,6 +38,11 @@
       supersonic.media
     </li>
   </super-navigate>
+  <super-navigate location="module#ModuleSpec?attribute-from-url-param=present">
+    <li class="item">
+      supersonic.module
+    </li>
+  </super-navigate>
   <super-navigate location="ui#UISpec">
     <li class="item">
       supersonic.ui


### PR DESCRIPTION
Adds `supersonic.module.attributes` with:

- `get(attributeName, defaultValue=null): String`
- `has(attributeName): boolean`

Allows handling incoming attributes to a module instance without referring to the underlying mechanisms or distinguishing between different attribute sources.