### PR TITLE
Feature/module transitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+
+connect-test-app:
+	(cd testApp && \
+		steroids connect \
+			--watch=../src \
+			--no-qrcode \
+			--livereload \
+			--simulate)
+
+connect-test-spec-app:
+	(cd testSpecApp && \
+		steroids connect \
+			--watch=../src \
+			--no-qrcode \
+			--livereload \
+			--simulate)

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "homepage": "https://github.com/AppGyver/supersonic",
   "devDependencies": {
     "canonical-path": "0.0.2",
-    "chai-as-promised": "^4.1.1",
+    "chai": "^3.0.0",
+    "chai-as-promised": "^5.1.0",
     "coffeeify": "^0.7.0",
     "cpr": "^0.3.2",
     "dox": "git+https://github.com/appgyver/dox-coffee#master",
@@ -53,9 +54,9 @@
     "mkdirp": "^0.5.0",
     "q": "^1.0.1",
     "semver": "^3.0.1",
-    "winston": "^0.8.0",
     "sinon": "~1.11.1",
-    "sinon-chai": "^2.6.0"
+    "sinon-chai": "^2.8.0",
+    "winston": "^0.8.0"
   },
   "config": {
     "blanket": {

--- a/src/supersonic/core.coffee
+++ b/src/supersonic/core.coffee
@@ -12,17 +12,18 @@ steroids = if global.steroids?
 logger = require('./core/logger')(steroids, global)
 data = require('./core/data')(logger, global)
 env = require('./core/env')(logger, global)
+ui = require('./core/ui')(steroids, logger, global)
 
 module.exports = {
   logger
   data
   env
+  ui
   debug: require('./core/debug')(steroids, logger)
   app: require('./core/app')(steroids, logger)
   media: require('./core/media')(steroids, logger)
-  module: require('./core/module')(logger)
+  module: require('./core/module')(steroids, ui, logger)
   device: require('./core/device')(steroids, logger)
-  ui: require('./core/ui')(steroids, logger, global)
   data: require('./core/data')(logger, global)
   auth: require('./core/auth')(logger, global, data, env)
   internal:

--- a/src/supersonic/core/module/index.coffee
+++ b/src/supersonic/core/module/index.coffee
@@ -2,3 +2,4 @@
 module.exports = (logger) ->
   initialModuleElements: require('./initial-module-elements')(logger)
   attributes: require('./attributes')(logger)
+  transitions: require('./transitions')(logger)

--- a/src/supersonic/core/module/index.coffee
+++ b/src/supersonic/core/module/index.coffee
@@ -1,5 +1,5 @@
 
-module.exports = (logger) ->
+module.exports = (steroids, ui, logger) ->
   initialModuleElements: require('./initial-module-elements')(logger)
   attributes: require('./attributes')(logger)
-  transitions: require('./transitions')(logger)
+  transitions: require('./transitions')(steroids, ui, logger)

--- a/src/supersonic/core/module/transitions.coffee
+++ b/src/supersonic/core/module/transitions.coffee
@@ -1,0 +1,2 @@
+module.exports = (logger) ->
+  {}

--- a/src/supersonic/core/module/transitions.coffee
+++ b/src/supersonic/core/module/transitions.coffee
@@ -1,2 +1,20 @@
-module.exports = (logger) ->
-  {}
+Promise = require 'bluebird'
+superify = require '../superify'
+
+module.exports = (steroids, ui, logger) ->
+  s = superify 'supersonic.module.transitions', logger
+
+  push: s.promiseF 'push', ->
+    ui.animate("slideFromRight", {
+      duration: 0.5
+      curve: "easeInOut"
+    }).perform().then ->
+      steroids.view.displayLoading()
+      Promise.delay(1000).then ->
+        steroids.view.removeLoading()
+
+  pop: s.promiseF 'pop', ->
+    supersonic.ui.animate("slideFromLeft", {
+      duration: 0.5
+      curve: "easeInOut"
+    }).perform()

--- a/tasks/build.coffee
+++ b/tasks/build.coffee
@@ -1,8 +1,12 @@
 module.exports = (grunt) ->
   grunt.registerTask 'build', [
+    'build-dist'
+    'compile-docs'
+  ]
+
+  grunt.registerTask 'build-dist', [
     'clean:build'
     'compile-coffee'
     'compile-components'
     'compile-stylesheets'
-    'compile-docs'
   ]

--- a/testApp/Gruntfile.coffee
+++ b/testApp/Gruntfile.coffee
@@ -24,7 +24,7 @@ module.exports = (grunt) ->
         dest: "#{__dirname}/bower_components/supersonic/"
     shell:
       "supersonic-build":
-        command: "grunt build"
+        command: "grunt build-dist"
         options:
           execOptions:
             cwd: '..'

--- a/testApp/app/module/views/index.html
+++ b/testApp/app/module/views/index.html
@@ -17,5 +17,10 @@
         Iframe size autoadjust <i class="icon super-ios7-arrow-right"></i>
       </li>
     </super-navigate>
+    <super-navigate location="module#transitions">
+      <li class="item item-icon-right">
+        Transitions <i class="icon super-ios7-arrow-right"></i>
+      </li>
+    </super-navigate>
   </ul>
 </div>

--- a/testApp/app/module/views/transitions.html
+++ b/testApp/app/module/views/transitions.html
@@ -1,0 +1,22 @@
+<div>
+
+  <super-navbar>
+    <super-navbar-title>
+      Transitions
+    </super-navbar-title>
+  </super-navbar>
+
+  <div class="padding">
+    <button
+      class="button button-block"
+      onclick="supersonic.module.transitions.push()">
+        push()
+    </button>
+
+    <button
+      class="button button-block"
+      onclick="supersonic.module.transitions.pop()">
+        pop()
+    </button>
+  </div>
+</div>

--- a/testSpecApp/Gruntfile.coffee
+++ b/testSpecApp/Gruntfile.coffee
@@ -18,7 +18,7 @@ module.exports = (grunt) ->
         dest: "bower_components/supersonic/dist/"
     shell:
       "supersonic-build":
-        command: "grunt build"
+        command: "grunt build-dist"
         options:
           execOptions:
             cwd: '..'

--- a/testSpecApp/app/module/scripts/TransitionSpec.coffee
+++ b/testSpecApp/app/module/scripts/TransitionSpec.coffee
@@ -1,0 +1,3 @@
+describe 'supersonic.module.transitions', ->
+  it 'is an object', ->
+    supersonic.module.should.have.property('transitions').be.an 'object'

--- a/testSpecApp/app/module/scripts/TransitionSpec.coffee
+++ b/testSpecApp/app/module/scripts/TransitionSpec.coffee
@@ -1,3 +1,23 @@
 describe 'supersonic.module.transitions', ->
   it 'is an object', ->
     supersonic.module.should.have.property('transitions').be.an 'object'
+
+  describe 'push', ->
+    it 'is a function', ->
+      supersonic.module.transitions.should.have.property('push').be.a 'function'
+
+    ###
+    NOTE: This doesn't work in tests, find out why!
+    ###
+    it.skip 'applies a transition and returns a promise on its completion', ->
+      supersonic.module.transitions.push().should.be.fulfilled
+
+  describe 'pop', ->
+    it 'is a function', ->
+      supersonic.module.transitions.should.have.property('pop').be.a 'function'
+
+    ###
+    NOTE: This doesn't work in tests, find out why!
+    ###
+    it.skip 'applies a transition and returns a promise on its completion', ->
+      supersonic.module.transitions.pop().should.be.fulfilled


### PR DESCRIPTION
Adds the `supersonic.module.transitions` namespace with functions `push` and `pop`. For use with ag-module-router to provide transition animations when changing between module views.

Caveat: push and pop don't execute when ran in test scenarios, but work fine outside. This didn't seem to be due to lack of `steroids.on 'ready'`. Signs point to some other steroids quirk.