### PR TITLE
supersonic.module.drivers

### DIFF
--- a/src/supersonic/core.coffee
+++ b/src/supersonic/core.coffee
@@ -4,6 +4,11 @@ global = if window?
     Window = require './mock/window'
     new Window()
 
+superglobal = if window?.top?
+    window.top
+  else
+    global
+
 steroids = if global.top?.steroids?
     global.top?.steroids
   else
@@ -22,7 +27,7 @@ module.exports = {
   debug: require('./core/debug')(steroids, logger)
   app: require('./core/app')(steroids, logger)
   media: require('./core/media')(steroids, logger)
-  module: require('./core/module')(steroids, logger, ui, env)
+  module: require('./core/module')(steroids, logger, superglobal, ui, env)
   device: require('./core/device')(steroids, logger)
   data: require('./core/data')(logger, global)
   auth: require('./core/auth')(logger, global, data, env)

--- a/src/supersonic/core/module/drivers.coffee
+++ b/src/supersonic/core/module/drivers.coffee
@@ -1,10 +1,13 @@
-module.exports = (steroids) ->
+module.exports = (steroids, superglobal) ->
 
-  currentDriver = null
+  superglobal.ag ?= {}
+  superglobal.ag.module ?= {}
+
   setCurrentDriver = (driver) ->
-    currentDriver = driver
+    superglobal.ag.module.driver = driver
+
   getCurrentDriver = ->
-    currentDriver
+    superglobal.ag.module.driver
 
   {
     mpa: require('./drivers/mpa')(steroids)

--- a/src/supersonic/core/module/drivers.coffee
+++ b/src/supersonic/core/module/drivers.coffee
@@ -1,0 +1,14 @@
+module.exports = (steroids) ->
+
+  currentDriver = null
+  setCurrentDriver = (driver) ->
+    currentDriver = driver
+  getCurrentDriver = ->
+    currentDriver
+
+  {
+    mpa: require('./drivers/mpa')(steroids)
+    current:
+      set: setCurrentDriver
+      get: getCurrentDriver
+  }

--- a/src/supersonic/core/module/drivers/mpa.coffee
+++ b/src/supersonic/core/module/drivers/mpa.coffee
@@ -1,0 +1,22 @@
+Promise = require 'bluebird'
+
+module.exports = (steroids) ->
+  layers:
+    push: (path) ->
+      new Promise (resolve, reject) ->
+        view = new steroids.views.WebView
+          location: path
+
+        steroids.layers.push { view }, {
+          onSuccess: resolve
+          onFailure: (error) ->
+            reject new Error error.errorDescription
+        }
+
+    pop: ->
+      new Promise (resolve, reject) ->
+        steroids.layers.pop {}, {
+          onSuccess: resolve
+          onFailure: (error) ->
+            reject new Error error.errorDescription
+        }

--- a/src/supersonic/core/module/index.coffee
+++ b/src/supersonic/core/module/index.coffee
@@ -1,9 +1,11 @@
 
-module.exports = (steroids, logger, ui, env) ->
+module.exports = (steroids, logger, superglobal, ui, env) ->
   router = require('./router')(logger, env)
-  drivers = require('./drivers')(steroids)
+  drivers = require('./drivers')(steroids, superglobal)
 
-  drivers.current.set(drivers.mpa)
+  # Set default driver unless it has been set in a parent frame
+  if !drivers.current.get()?
+    drivers.current.set(drivers.mpa)
 
   {
     router

--- a/src/supersonic/core/module/index.coffee
+++ b/src/supersonic/core/module/index.coffee
@@ -1,11 +1,15 @@
 
 module.exports = (steroids, logger, ui, env) ->
   router = require('./router')(logger, env)
+  drivers = require('./drivers')(steroids)
+
+  drivers.current.set(drivers.mpa)
 
   {
     router
+    drivers
     attributes: require('./attributes')(logger)
     initialModuleElements: require('./initial-module-elements')(logger)
-    layers: require('./layers')(logger, steroids, router)
+    layers: require('./layers')(logger, router, drivers.current.get)
     transitions: require('./transitions')(steroids, ui, logger)
   }

--- a/src/supersonic/core/module/layers.coffee
+++ b/src/supersonic/core/module/layers.coffee
@@ -1,27 +1,12 @@
 Promise = require 'bluebird'
 superify = require '../superify'
 
-module.exports = (logger, steroids, router) ->
+module.exports = (logger, router, getDriver) ->
   s = superify 'supersonic.module.layers', logger
 
   push: s.promiseF 'push', (route, params = {}) ->
-
     path = router.getPath route, params
-
-    new Promise (resolve, reject) ->
-      view = new steroids.views.WebView
-        location: path
-
-      steroids.layers.push { view }, {
-        onSuccess: resolve
-        onFailure: (error) ->
-          reject new Error error.errorDescription
-      }
+    Promise.resolve(getDriver().layers.push(path))
 
   pop: s.promiseF 'pop', ->
-    new Promise (resolve, reject) ->
-      steroids.layers.pop {}, {
-        onSuccess: resolve
-        onFailure: (error) ->
-          reject new Error error.errorDescription
-      }
+    Promise.resolve(getDriver().layers.pop())

--- a/test/module/DriverSpec.coffee
+++ b/test/module/DriverSpec.coffee
@@ -1,0 +1,27 @@
+chai = require('chai')
+chai.should()
+
+steroids = require '../../src/supersonic/mock/steroids'
+drivers = require('../../src/supersonic/core/module/drivers')(steroids)
+
+describe 'supersonic.module.drivers', ->
+  it 'is an object', ->
+    drivers.should.be.an 'object'
+
+  describe 'current', ->
+    it 'is an object', ->
+      drivers.should.have.property('current').be.an 'object'
+
+    describe 'set', ->
+      it 'is a function', ->
+        drivers.current.should.have.property('set').be.a 'function'
+
+    describe 'get', ->
+      it 'is a function', ->
+        drivers.current.should.have.property('get').be.a 'function'
+
+    it 'can be set and get', ->
+      newDriver = {}
+
+      drivers.current.set(newDriver)
+      drivers.current.get().should.equal newDriver

--- a/test/module/DriverSpec.coffee
+++ b/test/module/DriverSpec.coffee
@@ -2,7 +2,7 @@ chai = require('chai')
 chai.should()
 
 steroids = require '../../src/supersonic/mock/steroids'
-drivers = require('../../src/supersonic/core/module/drivers')(steroids)
+drivers = require('../../src/supersonic/core/module/drivers')(steroids, superglobal = {})
 
 describe 'supersonic.module.drivers', ->
   it 'is an object', ->

--- a/testSpecApp/app/module/scripts/DriverSpec.coffee
+++ b/testSpecApp/app/module/scripts/DriverSpec.coffee
@@ -1,0 +1,28 @@
+describe 'supersonic.module.drivers', ->
+  it 'is an object', ->
+    supersonic.module.should.have.property('drivers').be.an 'object'
+
+  describe 'mpa', ->
+    it 'is an object', ->
+      supersonic.module.drivers.should.have.property('mpa').be.an 'object'
+
+  describe 'current', ->
+    it 'is an object', ->
+      supersonic.module.drivers.should.have.property('current').be.an 'object'
+
+    describe 'get', ->
+      it 'defaults to the mpa driver', ->
+        supersonic.module.drivers.current.get().should.equal supersonic.module.drivers.mpa
+
+    describe 'set', ->
+      it 'sets the current driver', ->
+        newDriver =
+          layers:
+            push: ->
+            pop: ->
+
+        supersonic.module.drivers.current.set(newDriver)
+        supersonic.module.drivers.current.get().should.equal newDriver
+
+      after ->
+        supersonic.module.drivers.current.set(supersonic.module.drivers.mpa)

--- a/testSpecApp/app/module/scripts/DriverSpec.coffee
+++ b/testSpecApp/app/module/scripts/DriverSpec.coffee
@@ -14,15 +14,19 @@ describe 'supersonic.module.drivers', ->
       it 'defaults to the mpa driver', ->
         supersonic.module.drivers.current.get().should.equal supersonic.module.drivers.mpa
 
+    nullDriver =
+      layers:
+        push: ->
+        pop: ->
+
+    afterEach ->
+      supersonic.module.drivers.current.set(supersonic.module.drivers.mpa)
+
     describe 'set', ->
       it 'sets the current driver', ->
-        newDriver =
-          layers:
-            push: ->
-            pop: ->
+        supersonic.module.drivers.current.set(nullDriver)
+        supersonic.module.drivers.current.get().should.equal nullDriver
 
-        supersonic.module.drivers.current.set(newDriver)
-        supersonic.module.drivers.current.get().should.equal newDriver
-
-      after ->
-        supersonic.module.drivers.current.set(supersonic.module.drivers.mpa)
+    it 'is stored in the main frame', ->
+      supersonic.module.drivers.current.set(nullDriver)
+      nullDriver.should.equal window.top.ag?.module?.driver


### PR DESCRIPTION
Refactors `supersonic.module.layers` to access environment-specific functionality through `supersonic.module.drivers`. Allows accessing current driver for a view and all its iframes through `supersonic.module.drivers.current`. To provide your own driver, call `supersonic.module.drivers.current.set`. A default MPA driver is provided at `supersonic.module.drivers.mpa`.