### PR TITLE
fix (router) pass the moduleName and viewName to assertRequiredParamsExist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Issues are tracked in AppGyver's [unified issue tracker](https://github.com/appgyver/steroids/issues) – please post bug reports and feature requests there.
 
+## TBD
+
+Fix:
+- Fix a bug on module router that happens during the validation of required parameters.
+
 ## 1.6.3 (2015-08-07)
 
 Features:

--- a/src/supersonic/core/module/router.coffee
+++ b/src/supersonic/core/module/router.coffee
@@ -21,7 +21,7 @@ module.exports = (logger, env) ->
     env?.modules?.routes?[moduleName]?.views?[viewName]?.path?
 
   formatExplicitPath = do ->
-    assertRequiredParamsExist = (targetParams, params) ->
+    assertRequiredParamsExist = (moduleName, viewName, targetParams, params) ->
       for key, value of (targetParams ? {}) when value.required
         if !params?[key]?
           throw new Error "Missing required parameter '#{key}' for route to '#{moduleName}##{viewName}'"
@@ -39,7 +39,7 @@ module.exports = (logger, env) ->
     return (moduleName, viewName, params) ->
       target = env?.modules?.routes?[moduleName].views[viewName]
 
-      assertRequiredParamsExist target.params, params
+      assertRequiredParamsExist moduleName, viewName, target.params, params
 
       [ path, params ] = replaceTokensInPath target.path, params
 


### PR DESCRIPTION
This fixes a bug in the module router that happens during the validation of required parameters and the code tried to thrown an Error passing the module name and view name, but these variables were not in the closure scope.