### PR TITLE
Fix/isolate modal attribute scopes

### DIFF
--- a/src/supersonic/core/module/index.coffee
+++ b/src/supersonic/core/module/index.coffee
@@ -1,6 +1,6 @@
 
 module.exports = (steroids, logger, superglobal, ui, env, global, data, auth) ->
-  attributes = require('./attributes')(logger, global, superglobal)
+  attributes = require('./attributes')(logger, global)
   router = require('./router')(logger, env, global)
   drivers = require('./drivers')(steroids, superglobal, global)
 

--- a/src/supersonic/core/module/modal.coffee
+++ b/src/supersonic/core/module/modal.coffee
@@ -17,7 +17,12 @@ module.exports = (logger, router, getDriver, global) ->
    # @define {Object} attributes What attributes to pass to the target
   ###
   show: s.promiseF 'show', (route, attributes = {}) ->
+    # FIXME: What is this about?
     attributes["disable_header"] = true unless attributes["disable_header"]?
+
+    # KLUDGE: Prevent attributes from outside modal leaking into the modal in web
+    # See: ./attributes.coffee
+    attributes["ag-isolate-scope"] = true
 
     path = router.getPath route, attributes
     Promise.resolve(getDriver().modal.show(path, {

--- a/testApp/app/module/scripts/IsolatedIframeController.coffee
+++ b/testApp/app/module/scripts/IsolatedIframeController.coffee
@@ -1,0 +1,7 @@
+angular
+  .module('module')
+  .controller 'IsolatedIframeController', ($scope) ->
+    attributes = supersonic.module.attributes
+
+    $scope.hasAttributeFromTopFrame = attributes.has('isolated-iframe-should-not-get-access-to-this')
+    $scope.attributeFromTopFrame = attributes.get('isolated-iframe-should-not-get-access-to-this')

--- a/testApp/app/module/scripts/IsolatedIframeController.coffee
+++ b/testApp/app/module/scripts/IsolatedIframeController.coffee
@@ -5,3 +5,6 @@ angular
 
     $scope.hasAttributeFromTopFrame = attributes.has('isolated-iframe-should-not-get-access-to-this')
     $scope.attributeFromTopFrame = attributes.get('isolated-iframe-should-not-get-access-to-this')
+
+    $scope.hasAttributeFromIsolatedParentFrame = attributes.has('isolated-scope-should-see-this')
+    $scope.attributeFromIsolatedParentFrame = attributes.get('isolated-scope-should-see-this')

--- a/testApp/app/module/views/attribute-scope-isolation.html
+++ b/testApp/app/module/views/attribute-scope-isolation.html
@@ -1,0 +1,13 @@
+<div>
+
+  <super-navbar>
+    <super-navbar-title>
+      Attribute scope isolation
+    </super-navbar-title>
+  </super-navbar>
+
+  <iframe
+    data-module
+    src="attribute-scope-isolation/isolated-iframe.html?ag-isolate-scope">
+  </iframe>
+</div>

--- a/testApp/app/module/views/attribute-scope-isolation.html
+++ b/testApp/app/module/views/attribute-scope-isolation.html
@@ -8,6 +8,11 @@
 
   <iframe
     data-module
-    src="attribute-scope-isolation/isolated-iframe.html?ag-isolate-scope">
+    src="attribute-scope-isolation/isolated-iframe.html?ag-isolate-scope&amp;isolated-scope-should-see-this=true">
+  </iframe>
+
+  <iframe
+    data-module
+    src="attribute-scope-isolation/nest-isolated-frame.html?ag-isolate-scope&amp;isolated-scope-should-see-this=true">
   </iframe>
 </div>

--- a/testApp/app/module/views/attribute-scope-isolation/isolated-iframe.html
+++ b/testApp/app/module/views/attribute-scope-isolation/isolated-iframe.html
@@ -6,4 +6,9 @@
     <dd>Present: {{ hasAttributeFromTopFrame }}</dd>
     <dd>Value: {{ attributeFromTopFrame }}</dd>
   </dl>
+  <dl>
+    <dt><code>isolated-scope-should-see-this</code>:</dt>
+    <dd>Present: {{ hasAttributeFromIsolatedParentFrame }}</dd>
+    <dd>Value: {{ attributeFromIsolatedParentFrame }}</dd>
+  </dl>
 </div>

--- a/testApp/app/module/views/attribute-scope-isolation/isolated-iframe.html
+++ b/testApp/app/module/views/attribute-scope-isolation/isolated-iframe.html
@@ -1,0 +1,9 @@
+
+<div ng-controller="IsolatedIframeController">
+  <h4>supersonic.module.attributes</h4>
+  <dl>
+    <dt><code>isolated-iframe-should-not-get-access-to-this</code>:</dt>
+    <dd>Present: {{ hasAttributeFromTopFrame }}</dd>
+    <dd>Value: {{ attributeFromTopFrame }}</dd>
+  </dl>
+</div>

--- a/testApp/app/module/views/attribute-scope-isolation/nest-isolated-frame.html
+++ b/testApp/app/module/views/attribute-scope-isolation/nest-isolated-frame.html
@@ -1,0 +1,10 @@
+<div>
+
+  <h1> Nest one </h1>
+
+  <iframe
+    data-module
+    src="isolated-iframe.html">
+  </iframe>
+
+</div>

--- a/testApp/app/module/views/index.html
+++ b/testApp/app/module/views/index.html
@@ -12,6 +12,11 @@
         Attributes <i class="icon super-ios-arrow-right"></i>
       </li>
     </super-navigate>
+    <super-navigate location="module#attribute-scope-isolation?isolated-iframe-should-not-get-access-to-this=true">
+      <li class="item item-icon-right">
+        Attribute scope isolation <i class="icon super-ios-arrow-right"></i>
+      </li>
+    </super-navigate>
     <super-navigate location="module#data-channels">
       <li class="item item-icon-right">
         Data channels <i class="icon super-ios-arrow-right"></i>


### PR DESCRIPTION
Fixes a scenario where modal module iframes in web will read module attributes from the topmost frame. On mobile the attribute access is naturally from the modal dialog frame; this behavior is affected in web by adding a scope isolation parameter when opening module modals, and detecting for that when discovering where to read module attributes from.