### PR TITLE
Fix/driver route as uid

### DIFF
--- a/src/supersonic/core/module/layers.coffee
+++ b/src/supersonic/core/module/layers.coffee
@@ -17,9 +17,9 @@ module.exports = (logger, router, getDriver, global) ->
    # @define {Object} attributes What attributes to pass to the target
   ###
   push: s.promiseF 'push', (route, attributes = {}) ->
-    path = router.getPath route, attributes
+    { path, uid, attributes } = router.getMapping route, attributes
     Promise.resolve(getDriver().layers.push(path, {
-      route
+      route: uid
       attributes
       origin: global
     }))

--- a/src/supersonic/core/module/modal.coffee
+++ b/src/supersonic/core/module/modal.coffee
@@ -24,9 +24,9 @@ module.exports = (logger, router, getDriver, global) ->
     # See: ./attributes.coffee
     attributes["ag-isolate-scope"] = true
 
-    path = router.getPath route, attributes
+    { path, uid, attributes } = router.getMapping route, attributes
     Promise.resolve(getDriver().modal.show(path, {
-      route
+      route: uid
       attributes
       origin: global
     }))

--- a/testSpecApp/app/module/scripts/RouterSpec.coffee
+++ b/testSpecApp/app/module/scripts/RouterSpec.coffee
@@ -2,6 +2,18 @@ describe 'supersonic.module.router', ->
   it 'is an object', ->
     supersonic.module.should.have.property('router').be.an 'object'
 
+  describe 'interpret', ->
+    it 'is a function', ->
+      supersonic.module.router.should.have.property('interpret').be.a 'function'
+
+    it 'takes a route string and output its raw components', ->
+      supersonic.module.router.interpret('foo#bar?qux=baz').should.deep.equal {
+        moduleName: 'foo'
+        viewName: 'bar'
+        query:
+          qux: 'baz'
+      }
+
   describe 'getPath', ->
     it 'is a function', ->
       supersonic.module.router.should.have.property('getPath').be.a 'function'
@@ -15,3 +27,53 @@ describe 'supersonic.module.router', ->
               path: "bar"
 
       supersonic.module.router.getPath('foo').should.equal "bar"
+
+  describe 'getMapping', ->
+
+    it 'is a function', ->
+      supersonic.module.router.should.have.property('getMapping').be.a 'function'
+
+    it 'maps a route name and attributes to its components', ->
+      supersonic.env.modules ?= {}
+      supersonic.env.modules.routes =
+        foo:
+          views:
+            index:
+              path: "bar"
+
+      mapping = supersonic.module.router.getMapping 'foo'
+
+      mapping.should.have.property('path').equal 'bar'
+      mapping.should.have.property('uid').equal 'foo'
+      mapping.should.have.property('attributes').deep.equal {}
+
+    describe 'uid', ->
+      it 'is the same as a passed route name', ->
+        supersonic.env.modules ?= {}
+        supersonic.env.modules.routes =
+          foo:
+            views:
+              index:
+                path: "bar"
+
+        supersonic.module.router.getMapping('foo').uid.should.equal 'foo'
+
+      it 'is the same as a passed view', ->
+        supersonic.module.router.getMapping('#view').uid.should.equal '#view'
+
+    describe 'attributes', ->
+      it 'can be explicit', ->
+        supersonic.module.router
+          .getMapping('#view', foo: 'bar')
+          .attributes
+          .should.deep.equal {
+            foo: 'bar'
+          }
+
+      it 'can be detected from the route', ->
+        supersonic.module.router
+          .getMapping('#view?foo=bar')
+          .attributes
+          .should.deep.equal {
+            foo: 'bar'
+          }


### PR DESCRIPTION
If a route of the format `foo#bar?qux=baz` is passed to `supersonic.module` functions that accept routes, module drivers receive a `route` parameter that erroneously includes the query parameters included.

Adds a `router.getMapping` function that allows these functions to access the `path`, `uid` and `attributes` that routing was done based on instead of only the output `path`. Retains `router.getPath` for backwards compatibility.