### PR TITLE
Fix the setup for supersonic.auth.users

### DIFF
--- a/src/supersonic/core.coffee
+++ b/src/supersonic/core.coffee
@@ -1,3 +1,6 @@
+without = require './util/without'
+pick = require './util/pick'
+
 global = if window?
     window
   else
@@ -29,19 +32,18 @@ steroids = do ->
 logger = require('./core/logger')(steroids, global)
 env = require('./core/env')(logger, superglobal)
 data = require('./core/data')(logger, superglobal, env)
-auth = require('./core/auth')(logger, global, data, env)
 ui = require('./core/ui')(steroids, logger, global, superglobal, data)
 
 module.exports = {
   logger
-  data
   env
   ui
-  auth
+  data: without ['users', 'session'], data
+  auth: pick ['users', 'session'], data
   debug: require('./core/debug')(steroids, logger)
   app: require('./core/app')(steroids, logger)
   media: require('./core/media')(steroids, logger)
-  module: require('./core/module')(steroids, logger, superglobal, ui, env, global, data, auth)
+  module: require('./core/module')(steroids, logger, superglobal, ui, env, global, data)
   device: require('./core/device')(steroids, logger)
   internal:
     Promise: require 'bluebird'

--- a/src/supersonic/core/auth/index.coffee
+++ b/src/supersonic/core/auth/index.coffee
@@ -1,7 +1,0 @@
-module.exports = (logger, window, data, env) ->
-  users = require("./users")(logger, window, data.session, env)
-
-  {
-    session: data.session
-    users
-  }

--- a/src/supersonic/core/data/index.coffee
+++ b/src/supersonic/core/data/index.coffee
@@ -12,15 +12,15 @@ module.exports = (logger, superglobal, env) ->
 
   defaultAsyncStorageAdapter = adapters.localStorage
 
-  model = require('./model')(logger, superglobal, defaultAsyncStorageAdapter, session, env)
-  storage = { adapters, property }
-
-  requests = data.requests
+  loadResourceBundle = require('./model/load-resource-bundle')(logger, session, defaultAsyncStorageAdapter)
+  model = require('./model')(logger, superglobal, env, loadResourceBundle)
+  users = require('./users')(env, loadResourceBundle)
 
   {
     channel
     model
-    storage
     session
-    requests
+    users
+    storage: { adapters, property }
+    requests: data.requests
   }

--- a/src/supersonic/core/data/model.coffee
+++ b/src/supersonic/core/data/model.coffee
@@ -1,12 +1,7 @@
 data = require 'ag-data'
 Bacon = require 'baconjs'
 
-defaultPollBehavior = require './model/default-poll-behavior'
-
-DEFAULT_BACKEND_POLL_INTERVAL_MILLISECONDS = 10000
-DEFAULT_CACHE_POLL_INTERVAL_MILLISECONDS = 1000
-
-module.exports = (logger, superglobal, getDefaultCacheStorage, session, env) ->
+module.exports = (logger, superglobal, env, loadResourceBundle) ->
   ###
    # @namespace supersonic.data
    # @name model
@@ -54,28 +49,6 @@ module.exports = (logger, superglobal, getDefaultCacheStorage, session, env) ->
    # // Persist our new Task instance to the cloud
    # takeOutTheTrash.save();
   ###
-  withDefaults = (name, options) ->
-    if options.cache?.enabled != false
-      options.cache ?= {}
-      options.cache.enabled = true
-
-    if options.cache.enabled
-      unless options.cache.storage?
-        options.cache.storage = getDefaultCacheStorage()
-
-    if not options.headers?.Authorization?
-      options.headers ?= {}
-      options.headers.Authorization = session.getAccessToken()
-
-    options.followable ?= {
-      poll: defaultPollBehavior name
-      interval: switch options.cache.enabled
-        when true then DEFAULT_CACHE_POLL_INTERVAL_MILLISECONDS
-        else DEFAULT_BACKEND_POLL_INTERVAL_MILLISECONDS
-    }
-
-    options
-
   createModel = do ->
     bundleDefinition = switch
       when env?.data?.bundle? then env.data.bundle
@@ -90,17 +63,7 @@ module.exports = (logger, superglobal, getDefaultCacheStorage, session, env) ->
     # are correctly wrapped and logged. Notably, if window.ag.data exists but
     # does not define a valid bundle, an error will be logged without interaction.
     try
-      bundle = data.loadResourceBundle bundleDefinition
-
-      return (name, options = {}) ->
-        options = withDefaults(name, options)
-
-        try
-          bundle.createModel name, options
-        catch err
-          logger.error "Tried to access cloud resource '#{name}', but it is not a configured resource"
-          throw new Error "Could not load model #{name}: #{err}"
-
+      return loadResourceBundle(bundleDefinition).createModel
     catch err
       logger.error "Tried to access a cloud resource, but the configured cloud resource bundle could not be loaded"
       ->

--- a/src/supersonic/core/data/model/load-resource-bundle.coffee
+++ b/src/supersonic/core/data/model/load-resource-bundle.coffee
@@ -1,0 +1,42 @@
+data = require 'ag-data'
+
+defaultPollBehavior = require './default-poll-behavior'
+
+DEFAULT_BACKEND_POLL_INTERVAL_MILLISECONDS = 10000
+DEFAULT_CACHE_POLL_INTERVAL_MILLISECONDS = 1000
+
+module.exports = (logger, session, getDefaultCacheStorage) ->
+
+  withDefaults = (name, options) ->
+    if options.cache?.enabled != false
+      options.cache ?= {}
+      options.cache.enabled = true
+
+    if options.cache.enabled
+      unless options.cache.storage?
+        options.cache.storage = getDefaultCacheStorage()
+
+    if not options.headers?.Authorization?
+      options.headers ?= {}
+      options.headers.Authorization = session.getAccessToken()
+
+    options.followable ?= {
+      poll: defaultPollBehavior name
+      interval: switch options.cache.enabled
+        when true then DEFAULT_CACHE_POLL_INTERVAL_MILLISECONDS
+        else DEFAULT_BACKEND_POLL_INTERVAL_MILLISECONDS
+    }
+
+    options
+
+  return loadResourceBundle = (bundleDefinition) ->
+    bundle = data.loadResourceBundle bundleDefinition
+
+    createModel: (name, options = {}) ->
+      options = withDefaults(name, options)
+
+      try
+        bundle.createModel name, options
+      catch err
+        logger.error "Tried to access cloud resource '#{name}', but it is not a configured resource"
+        throw new Error "Could not load model #{name}: #{err}"

--- a/src/supersonic/core/data/users.coffee
+++ b/src/supersonic/core/data/users.coffee
@@ -1,12 +1,9 @@
-data = require 'ag-data'
 Promise = require 'bluebird'
 
-module.exports = (logger, window, session, env) ->
+module.exports = (env, loadResourceBundle) ->
   usersResourceBundle =
     options:
       baseUrl: env?.auth?.endpoint || ""
-      headers:
-        Authorization: session.getAccessToken() || ""
     resources:
       users:
         schema:
@@ -28,14 +25,12 @@ module.exports = (logger, window, session, env) ->
             password:
               type: "string"
 
-  resourceBundle = data.loadResourceBundle(usersResourceBundle)
+  UserModel = loadResourceBundle(usersResourceBundle).createModel("users")
 
-  userModel = resourceBundle.createModel("users")
-
-  userModel.getCurrentUser = ->
+  UserModel.getCurrentUser = ->
     if userId = session.getUserId()
-      userModel.find(userId)
+      UserModel.find(userId)
     else
       Promise.reject new Error "Cannot access current user without a valid session"
 
-  userModel
+  UserModel

--- a/src/supersonic/core/module/index.coffee
+++ b/src/supersonic/core/module/index.coffee
@@ -1,5 +1,5 @@
 
-module.exports = (steroids, logger, superglobal, ui, env, global, data, auth) ->
+module.exports = (steroids, logger, superglobal, ui, env, global, data) ->
   attributes = require('./attributes')(logger, global)
   router = require('./router')(logger, env, global)
   drivers = require('./drivers')(steroids, superglobal, global)
@@ -20,6 +20,6 @@ module.exports = (steroids, logger, superglobal, ui, env, global, data, auth) ->
     iframes: require('./iframes')(global, superglobal)
     layers: require('./layers')(logger, router, drivers.current.get, global)
     modal: require('./modal')(logger, router, drivers.current.get, global)
-    notifications: require('./notifications')(data, attributes, auth)
+    notifications: require('./notifications')(data, attributes, data.session)
     transitions: require('./transitions')(steroids, ui, logger)
   }

--- a/src/supersonic/core/module/notifications.coffee
+++ b/src/supersonic/core/module/notifications.coffee
@@ -3,7 +3,7 @@ merge = require 'lodash/object/merge'
 
 APPGYVER_NOTIFICATION_RESOURCE_NAME = 'AppGyverNotification'
 
-module.exports = (data, attributes, auth) ->
+module.exports = (data, attributes, session) ->
 
   createAnnouncer = (namespace, events, defaults, resourceName) ->
     announcer =
@@ -124,7 +124,7 @@ module.exports = (data, attributes, auth) ->
         throw new Error "A list of event names is required"
 
       context = guessContext attributes
-      defaults = makeDefaults namespace, context, auth.session
+      defaults = makeDefaults namespace, context, session
       resourceName = options.resourceName ? APPGYVER_NOTIFICATION_RESOURCE_NAME
 
       createAnnouncer namespace, events, defaults, resourceName

--- a/src/supersonic/util/pick.coffee
+++ b/src/supersonic/util/pick.coffee
@@ -1,0 +1,5 @@
+module.exports = pick = (keys, object) ->
+  result = {}
+  for key, value of object when (key in keys)
+    result[key] = value
+  result

--- a/src/supersonic/util/without.coffee
+++ b/src/supersonic/util/without.coffee
@@ -1,0 +1,5 @@
+module.exports = without = (keys, object) ->
+  result = {}
+  for key, value of object when not (key in keys)
+    result[key] = value
+  result

--- a/test/DataSpec.coffee
+++ b/test/DataSpec.coffee
@@ -20,12 +20,14 @@ data = (resourceBundle = null) ->
   }
 
   session = require('../src/supersonic/core/data/session')(syncStorageAdapter())
+  loadResourceBundle = require('../src/supersonic/core/data/model/load-resource-bundle')(logger, session, asyncStorageAdapter)
+  env = {}
 
   model = require('../src/supersonic/core/data/model')(
     logger
     window
-    asyncStorageAdapter
-    session
+    env
+    loadResourceBundle
   )
 
   return {


### PR DESCRIPTION
Queries made through `supersonic.auth.users` had significant delays and/or were prevented from completing altogether.

`supersonic.auth.users` was created directly through `ag-data` without adding in the same configuration parameters as in `supersonic.data.model`. Among other things, this prevented caching from being enabled.

The underlying mechanism for this failure was not researched and is unknown. It's possible that `ag-data` does not function correctly in the absence of caching.