### PR TITLE
Fix typo which causes a breaking error when location service is …

### DIFF
--- a/src/supersonic/core/superify.coffee
+++ b/src/supersonic/core/superify.coffee
@@ -55,7 +55,7 @@ module.exports = (namespace, logger) ->
       .mapError((error) ->
         # Debuggify stream error
         logger.error "#{namespace}.#{name} produced an error: #{error}"
-        new Bacon.Error err
+        new Bacon.Error error
       )
 
     # Callbackify stream value


### PR DESCRIPTION
…disabled on IOS.

See http://community.appgyver.io/t/geolocation-when-gps-is-not-enable-err-ios-only/5434