### PR TITLE
Fix/query selector all

### DIFF
--- a/src/supersonic/core/module/iframes.coffee
+++ b/src/supersonic/core/module/iframes.coffee
@@ -205,7 +205,7 @@ module.exports = (window, superglobal) ->
   ###
 
   findAll = (selector = IFRAME_SELECTOR) ->
-    Array.prototype.slice.call window.document.body.querySelectorAll(selector)
+    Array.prototype.slice.call (window.document?.body?.querySelectorAll?(selector) || [])
 
   register = (element) ->
     return unless isValidFrame element

--- a/test/module/IframeSpec.coffee
+++ b/test/module/IframeSpec.coffee
@@ -1,0 +1,15 @@
+chai = require('chai')
+chai.should()
+
+iframes = require('../../src/supersonic/core/module/iframes')(global = {}, superglobal = {})
+
+describe 'supersonic.module.iframes', ->
+  it 'is an object', ->
+    iframes.should.be.an 'object'
+
+  describe 'findAll', ->
+    it 'is a function', ->
+      iframes.should.have.property('findAll').be.a 'function'
+
+    it 'should return an empty array when there is no document body', ->
+      iframes.findAll().should.deep.equal []


### PR DESCRIPTION
Prevents spurious console errors in scenarios where `supersonic.module.iframes.findAll()` is called when a module iframe doesn't have a valid `document.body`. This happens eg. when refreshing a page while the browser tears down existing iframes.